### PR TITLE
removed "--login" from scripts and added PBS directives.

### DIFF
--- a/Fill_GEFS_from_aws.sh
+++ b/Fill_GEFS_from_aws.sh
@@ -1,4 +1,9 @@
-#!/bin/ksh --login 
+#!/bin/ksh
+#####################################################
+# machine set up (users should change this part)
+#####################################################
+
+# For Hera, Jet, Orio
 #SBATCH --time=23:30:00
 #SBATCH --qos=batch
 #SBATCH --partition=service
@@ -6,6 +11,14 @@
 #SBATCH --account=zrtrr
 #SBATCH --job-name=Fill_GEFS_from_aws
 #SBATCH --output=./Fill_GEFS_from_aws.log
+
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N Fill_GEFS_from_aws
+#PBS -j oe -o log.Fill_GEFS_from_aws
 
 # https://noaa-gefs-pds.s3.amazonaws.com/gefs.20220429/00/atmos/pgrb2ap5/gep01.t00z.pgrb2a.0p50.f114
 # https://noaa-gefs-pds.s3.amazonaws.com/gefs.20220429/00/atmos/pgrb2bp5/gep01.t00z.pgrb2b.0p50.f114

--- a/getFV3GDASensembles
+++ b/getFV3GDASensembles
@@ -41,7 +41,7 @@ for HH in 00 06 12 18; do
 HPSSDIR=/NCEPPROD/5year/hpssprod/runhistory/rh${YYYY}/${YYYY}${MM}/${YYYY}${MM}${DD}
 
 #make links
-for k in $(seq -w 1 30); do
+for k in $(seq -w 1 80); do
   #ln -sf ./enkfgdas.${YYYY}${MM}${DD}/${HH}/mem0${k}/gdas.t${HH}z.atmf009.nemsio ${JDATE}.gdas.t${HH}z.atmf009s.mem0${k}.nemsio  # 2020
   ln -sf ./enkfgdas.${YYYY}${MM}${DD}/${HH}/atmos/mem0${k}/gdas.t${HH}z.atmf009.nc ${JDATE}.gdas.t${HH}z.atmf009.mem0${k}.nc     # 2021--now
 done

--- a/getFV3GDASensembles
+++ b/getFV3GDASensembles
@@ -1,17 +1,24 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
-
 #SBATCH --partition=service   ## maxium 23:30 hours
 #SBATCH --time=23:00:00
 #SBATCH --job-name=get_gdasenkf
 #SBATCH -o log.gdasenkf
 
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_gdasenkf
+#PBS -j oe -o log.gdasenkf
 
 set -ax
 
@@ -34,7 +41,7 @@ for HH in 00 06 12 18; do
 HPSSDIR=/NCEPPROD/5year/hpssprod/runhistory/rh${YYYY}/${YYYY}${MM}/${YYYY}${MM}${DD}
 
 #make links
-for k in $(seq -w 1 80); do
+for k in $(seq -w 1 30); do
   #ln -sf ./enkfgdas.${YYYY}${MM}${DD}/${HH}/mem0${k}/gdas.t${HH}z.atmf009.nemsio ${JDATE}.gdas.t${HH}z.atmf009s.mem0${k}.nemsio  # 2020
   ln -sf ./enkfgdas.${YYYY}${MM}${DD}/${HH}/atmos/mem0${k}/gdas.t${HH}z.atmf009.nc ${JDATE}.gdas.t${HH}z.atmf009.mem0${k}.nc     # 2021--now
 done

--- a/get_raphrrrsoil.ksh
+++ b/get_raphrrrsoil.ksh
@@ -1,8 +1,9 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
@@ -10,6 +11,14 @@
 #SBATCH --time=08:00:00
 #SBATCH --job-name=get_raphrrrsoil
 #SBATCH -o log.raphrrrsoil
+
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_raphrrrsoil
+#PBS -j oe -o log.rapsoil
 
 
 # EXPORT list here

--- a/gfs.ksh
+++ b/gfs.ksh
@@ -1,8 +1,9 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
@@ -10,6 +11,14 @@
 #SBATCH --time=08:00:00
 #SBATCH --job-name=get_gfsFcst
 #SBATCH -o log.gfsFcst
+
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_gfsFcst
+#PBS -j oe -o log.gfsFcst
 
 #-----------------#
 # gfs forecast #

--- a/gvf.ksh
+++ b/gvf.ksh
@@ -1,8 +1,9 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
@@ -11,6 +12,13 @@
 #SBATCH --job-name=get_gvfObs
 #SBATCH -o log.gvfObs
 
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_gvfObs
+#PBS -j oe -o log.gvfObs
 
 #------#
 # gvf

--- a/lightning.ksh
+++ b/lightning.ksh
@@ -1,8 +1,9 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
@@ -11,6 +12,13 @@
 #SBATCH --job-name=get_lightningObs
 #SBATCH -o log.lightningObs
 
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_lightningObs
+#PBS -j oe -o log.lightningObs
 
 #-----------------------#
 # lightning observation #

--- a/obsrap.ksh
+++ b/obsrap.ksh
@@ -1,8 +1,9 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
@@ -11,6 +12,13 @@
 #SBATCH --job-name=get_rapObs
 #SBATCH -o log.rapObs
 
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_rapObs
+#PBS -j oe -o log.rapObs
 
 #-----------------#
 # rap observation #

--- a/refl.ksh
+++ b/refl.ksh
@@ -1,8 +1,9 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
@@ -11,6 +12,13 @@
 #SBATCH --job-name=get_reflObs
 #SBATCH -o log.reflObs
 
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_reflObs
+#PBS -j oe -o log.reflObs
 
 #--------------#
 # reflectivity

--- a/retrieve_dsg_GEFS.sh
+++ b/retrieve_dsg_GEFS.sh
@@ -1,4 +1,9 @@
-#!/bin/ksh --login 
+#!/bin/ksh
+#####################################################
+# machine set up (users should change this part)
+#####################################################
+
+# For Hera, Jet, Orion
 #SBATCH --time=23:30:00
 #SBATCH --qos=batch
 #SBATCH --partition=service
@@ -6,6 +11,15 @@
 #SBATCH --account=zrtrr
 #SBATCH --job-name=retrieve_dsg_gefs
 #SBATCH --output=./retrieve_dsg_gefs.log
+
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N retrieve_dsg_gefs
+#PBS -j oe -o log.retrieve_dsg_gefs
+
 set -x
 
 module load hpss

--- a/retro_check.ksh
+++ b/retro_check.ksh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 #set -euax
 

--- a/snow.ksh
+++ b/snow.ksh
@@ -1,8 +1,9 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
@@ -10,6 +11,14 @@
 #SBATCH --time=08:00:00
 #SBATCH --job-name=get_snowObs
 #SBATCH -o log.snowObs
+
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_snowObs
+#PBS -j oe -o log.snowObs
 
 
 #------#

--- a/sst.ksh
+++ b/sst.ksh
@@ -1,8 +1,9 @@
-#!/bin/ksh --login
+#!/bin/ksh
 #####################################################
 # machine set up (users should change this part)
 #####################################################
 
+# For Hera, Jet, Orion
 #SBATCH --account=zrtrr
 #SBATCH --qos=batch
 #SBATCH --ntasks=1
@@ -11,6 +12,13 @@
 #SBATCH --job-name=get_sstObs
 #SBATCH -o log.sstObs
 
+# For WCOSS2
+#PBS -A RRFS-DEV
+#PBS -q dev_transfer
+#PBS -l select=1:ncpus=1:mem=2G
+#PBS -l walltime=06:00:00
+#PBS -N get_sstObs
+#PBS -j oe -o log.sstObs
 
 #------#
 # sst


### PR DESCRIPTION
"--login" was removed from all scripts since that is not allowed on WCOSS2. Users doing so will have their accounts disabled.

#PBS directives were added to each script. I found that you can list both #SBATCH and #PBS directives and the system will know which to use.

Fixes issue#1 https://github.com/NOAA-GSL/rrfs-stagedata/issues